### PR TITLE
Handle weather load failures and use HTTPS icons

### DIFF
--- a/lib/models/weather_model.dart
+++ b/lib/models/weather_model.dart
@@ -16,7 +16,7 @@ class Weather {
       cityName: json['name'],
       temperature: json['main']['temp'].toDouble(),
       condition: json['weather'][0]['description'],
-      iconUrl: 'http://openweathermap.org/img/wn/${json['weather'][0]['icon']}@2x.png',
+      iconUrl: 'https://openweathermap.org/img/wn/${json['weather'][0]['icon']}@2x.png',
     );
   }
 }

--- a/lib/pages/weather_page.dart
+++ b/lib/pages/weather_page.dart
@@ -130,10 +130,12 @@ class _WeatherPageState extends State<WeatherPage> {
           child: Center(
             child: _loading
               ? const CircularProgressIndicator()
-              : Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    if (_displayCity != null) ...[
+              : (_weather == null)
+                  ? const Text('Erro ao carregar clima')
+                  : Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        if (_displayCity != null) ...[
                       Row(
                         mainAxisSize: MainAxisSize.min,
                         children: [


### PR DESCRIPTION
## Summary
- show friendly error message instead of crashing when weather data fails to load
- load weather icons over HTTPS

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689913e97704832ea0791da3c1e516b7