### PR TITLE
Add profile tab with user settings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,21 +1,30 @@
 import 'package:flutter/material.dart';
-import 'package:weather_app/pages/weather_page.dart';
+import 'package:provider/provider.dart';
+import 'package:weather_app/models/user_model.dart';
 import 'package:weather_app/splash/splash_screen.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    ChangeNotifierProvider(
+      create: (_) => UserModel(),
+      child: const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: SplashScreen(),
-    );
-  }
+    @override
+    Widget build(BuildContext context) {
+      final user = context.watch<UserModel>();
+      return MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData.light(),
+        darkTheme: ThemeData.dark(),
+        themeMode: user.darkMode ? ThemeMode.dark : ThemeMode.light,
+        home: SplashScreen(),
+      );
+    }
 }
   

--- a/lib/models/user_model.dart
+++ b/lib/models/user_model.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+enum TemperatureUnit { celsius, fahrenheit }
+
+class UserModel extends ChangeNotifier {
+  String name;
+  String avatarUrl;
+  bool isLoggedIn;
+  TemperatureUnit unit;
+  bool darkMode;
+
+  UserModel({
+    this.name = 'Convidado',
+    this.avatarUrl = '',
+    this.isLoggedIn = false,
+    this.unit = TemperatureUnit.celsius,
+    this.darkMode = false,
+  });
+
+  void toggleUnit() {
+    unit = unit == TemperatureUnit.celsius
+        ? TemperatureUnit.fahrenheit
+        : TemperatureUnit.celsius;
+    notifyListeners();
+  }
+
+  void toggleTheme() {
+    darkMode = !darkMode;
+    notifyListeners();
+  }
+
+  void login(String newName) {
+    name = newName;
+    isLoggedIn = true;
+    notifyListeners();
+  }
+
+  void logout() {
+    name = 'Convidado';
+    isLoggedIn = false;
+    notifyListeners();
+  }
+}

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:weather_app/models/user_model.dart';
+import 'package:weather_app/pages/weather_page.dart';
+
+class ProfilePage extends StatelessWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = context.watch<UserModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Perfil'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            CircleAvatar(
+              radius: 40,
+              backgroundImage:
+                  user.avatarUrl.isNotEmpty ? NetworkImage(user.avatarUrl) : null,
+              child: user.avatarUrl.isEmpty
+                  ? const Icon(Icons.person, size: 40)
+                  : null,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              user.name,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 24),
+            SwitchListTile(
+              title: const Text('Modo escuro'),
+              value: user.darkMode,
+              onChanged: (_) => user.toggleTheme(),
+            ),
+            SwitchListTile(
+              title: const Text('Usar Fahrenheit'),
+              value: user.unit == TemperatureUnit.fahrenheit,
+              onChanged: (_) => user.toggleUnit(),
+            ),
+            const SizedBox(height: 24),
+            if (!user.isLoggedIn) ...[
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  ElevatedButton(
+                    onPressed: () => user.login('Usuário'),
+                    child: const Text('Login'),
+                  ),
+                  const SizedBox(width: 12),
+                  ElevatedButton(
+                    onPressed: () => user.login('Novo usuário'),
+                    child: const Text('Registrar'),
+                  ),
+                ],
+              ),
+            ] else ...[
+              ElevatedButton(
+                onPressed: user.logout,
+                child: const Text('Sair'),
+              ),
+            ],
+          ],
+        ),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: 1,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.cloud),
+            label: 'Clima',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person),
+            label: 'Perfil',
+          ),
+        ],
+        onTap: (index) {
+          if (index == 0) {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(builder: (_) => const WeatherPage()),
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/weather_page.dart
+++ b/lib/pages/weather_page.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:lottie/lottie.dart';
-import 'package:weather_app/effects/animated_weather_background.dart';
-import 'package:weather_app/service/weather_service.dart';
-import 'package:weather_app/models/weather_model.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:lottie/lottie.dart';
+import 'package:provider/provider.dart';
+import 'package:weather_app/effects/animated_weather_background.dart';
+import 'package:weather_app/models/user_model.dart';
+import 'package:weather_app/models/weather_model.dart';
+import 'package:weather_app/pages/profile_page.dart';
+import 'package:weather_app/service/weather_service.dart';
 
 class WeatherPage extends StatefulWidget {
   const WeatherPage({Key? key}) : super(key: key);
@@ -115,15 +118,20 @@ class _WeatherPageState extends State<WeatherPage> {
     return _conditionPt[key] ?? key[0].toUpperCase() + key.substring(1);
   }
 
+  double _displayTemp(double tempC, TemperatureUnit unit) {
+    return unit == TemperatureUnit.celsius ? tempC : tempC * 9 / 5 + 32;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final user = context.watch<UserModel>();
     return Scaffold(
       body: Stack(
-        children: [
-          // Fundo com efeitos animados
-          AnimatedWeatherBackground(
-            condition: _normalizedCondition(_weather?.condition),
-          ),
+          children: [
+            // Fundo com efeitos animados
+            AnimatedWeatherBackground(
+              condition: _normalizedCondition(_weather?.condition),
+            ),
 
           SafeArea(
             child: Center(
@@ -167,13 +175,13 @@ class _WeatherPageState extends State<WeatherPage> {
 
                         const SizedBox(height: 16),
 
-                        Text(
-                          '${_weather!.temperature.round()}°C',
-                          style: TextStyle(
-                            fontSize: 48,
-                            fontWeight: FontWeight.w700,
-                            color: isDayTime ? Colors.black : Colors.white,
-                            shadows: const [
+                          Text(
+                            '${_displayTemp(_weather!.temperature, user.unit).round()}°${user.unit == TemperatureUnit.celsius ? 'C' : 'F'}',
+                            style: TextStyle(
+                              fontSize: 48,
+                              fontWeight: FontWeight.w700,
+                              color: isDayTime ? Colors.black : Colors.white,
+                              shadows: const [
                               Shadow(blurRadius: 4, color: Colors.black38),
                             ],
                           ),
@@ -204,8 +212,31 @@ class _WeatherPageState extends State<WeatherPage> {
                     ),
             ),
           ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: 0,
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.cloud),
+            label: 'Clima',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person),
+            label: 'Perfil',
+          ),
         ],
+        onTap: (index) {
+          if (index == 1) {
+            Navigator.pushReplacement(
+              context,
+              MaterialPageRoute(builder: (_) => const ProfilePage()),
+            );
+          }
+        },
       ),
     );
   }
 }
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   geocoding: ^4.0.0
   lottie: ^3.3.1
   video_player: ^2.5.0
+  provider: ^6.1.2
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add provider-based user model to store login, theme, and unit preferences
- implement profile page with avatar, authentication buttons, and settings
- integrate profile tab and temperature unit conversion in weather page

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fc91cd4c832e836ef5bf9ba53e35