### PR TITLE
feat: add global animation toggle

### DIFF
--- a/lib/context/animation_context.dart
+++ b/lib/context/animation_context.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AnimationContext extends StatefulWidget {
+  final Widget child;
+  const AnimationContext({super.key, required this.child});
+
+  static _AnimationControllerInherited of(BuildContext context) {
+    return _AnimationControllerInherited.of(context);
+  }
+
+  @override
+  State<AnimationContext> createState() => _AnimationContextState();
+}
+
+class _AnimationContextState extends State<AnimationContext> {
+  bool _enabled = true;
+
+  bool get animationsEnabled => _enabled;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPreference();
+  }
+
+  Future<void> _loadPreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _enabled = prefs.getBool('animationsEnabled') ?? true;
+    });
+  }
+
+  Future<void> toggle() async {
+    setState(() {
+      _enabled = !_enabled;
+    });
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('animationsEnabled', _enabled);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _AnimationControllerInherited(
+      enabled: _enabled,
+      toggle: toggle,
+      child: widget.child,
+    );
+  }
+}
+
+class _AnimationControllerInherited extends InheritedWidget {
+  final bool enabled;
+  final Future<void> Function() toggle;
+
+  const _AnimationControllerInherited({
+    required this.enabled,
+    required this.toggle,
+    required super.child,
+  });
+
+  static _AnimationControllerInherited of(BuildContext context) {
+    final inherited = context
+        .dependOnInheritedWidgetOfExactType<_AnimationControllerInherited>();
+    assert(inherited != null, 'No AnimationContext found in context');
+    return inherited!;
+  }
+
+  @override
+  bool updateShouldNotify(
+      covariant _AnimationControllerInherited oldWidget) {
+    return enabled != oldWidget.enabled;
+  }
+}

--- a/lib/effects/animated_weather_background.dart
+++ b/lib/effects/animated_weather_background.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
+import 'package:weather_app/context/animation_context.dart';
 import 'package:weather_app/effects/painters/animated_sun.dart';
 
 class AnimatedWeatherBackground extends StatefulWidget {
@@ -36,12 +37,26 @@ class _AnimatedWeatherBackgroundState extends State<AnimatedWeatherBackground>
           }
         }
         setState(() {});
-      })
-      ..repeat();
+      });
 
     for (int i = 0; i < 100; i++) {
       _particles.add(_Particle(_random));
     }
+  }
+
+  void _updateAnimationStatus() {
+    final enabled = AnimationContext.of(context).enabled;
+    if (enabled && !_controller.isAnimating) {
+      _controller.repeat();
+    } else if (!enabled && _controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _updateAnimationStatus();
   }
 
   @override
@@ -70,6 +85,10 @@ class _AnimatedWeatherBackgroundState extends State<AnimatedWeatherBackground>
 
   @override
   Widget build(BuildContext context) {
+    final animEnabled = AnimationContext.of(context).enabled;
+    if (!animEnabled) {
+      return Container(color: _backgroundColor());
+    }
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, _) {
@@ -81,23 +100,16 @@ class _AnimatedWeatherBackgroundState extends State<AnimatedWeatherBackground>
           color: _backgroundColor(),
           child: Stack(
             children: [
-              // 🌞 Sol animado
               if (widget.condition == 'clear') const AnimatedSun(),
-
-              // ☁️ Nuvens animadas
               if (widget.condition == 'clouds')
                 CustomPaint(
                   painter: _CloudPainter(_controller.value),
                   size: Size.infinite,
                 ),
-
-              // 🌧️ Partículas de clima
               CustomPaint(
                 painter: _WeatherPainter(widget.condition, _particles),
                 size: Size.infinite,
               ),
-
-              // ⚡ Relâmpagos
               if (widget.condition == 'thunderstorm')
                 Container(
                   color: Colors.white.withOpacity(_lightningOpacity),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:weather_app/context/animation_context.dart';
 import 'package:weather_app/pages/weather_page.dart';
 import 'package:weather_app/splash/splash_screen.dart';
 
@@ -12,9 +13,11 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      debugShowCheckedModeBanner: false,
-      home: SplashScreen(),
+    return AnimationContext(
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        home: SplashScreen(),
+      ),
     );
   }
 }

--- a/lib/pages/weather_page.dart
+++ b/lib/pages/weather_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
+import 'package:weather_app/context/animation_context.dart';
 import 'package:weather_app/effects/animated_weather_background.dart';
 import 'package:weather_app/service/weather_service.dart';
 import 'package:weather_app/models/weather_model.dart';
@@ -117,14 +118,24 @@ class _WeatherPageState extends State<WeatherPage> {
 
   @override
   Widget build(BuildContext context) {
+    final animCtx = AnimationContext.of(context);
     return Scaffold(
+      appBar: AppBar(
+        title: const Text('Clima'),
+        actions: [
+          IconButton(
+            icon: Icon(animCtx.enabled
+                ? Icons.motion_photos_on
+                : Icons.motion_photos_off),
+            onPressed: () => animCtx.toggle(),
+          ),
+        ],
+      ),
       body: Stack(
         children: [
-          // Fundo com efeitos animados
           AnimatedWeatherBackground(
             condition: _normalizedCondition(_weather?.condition),
           ),
-
           SafeArea(
             child: Center(
               child: _loading
@@ -132,7 +143,6 @@ class _WeatherPageState extends State<WeatherPage> {
                   : Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
-                        // Botão de teste para alternar entre climas
                         ElevatedButton(
                           onPressed: () {
                             setState(() {
@@ -152,21 +162,21 @@ class _WeatherPageState extends State<WeatherPage> {
                                 cityName: _displayCity ?? "Cidade Teste",
                                 temperature: 20,
                                 condition: testConditions[next],
-                                iconUrl: '', 
+                                iconUrl: '',
                               );
                             });
                           },
                           child: const Text('Alterar Clima (Teste)'),
                         ),
                         const SizedBox(height: 16),
-
                         SizedBox(
                           height: 200,
-                          child: Lottie.asset(_animFor(_weather?.condition)),
+                          child: Lottie.asset(
+                            _animFor(_weather?.condition),
+                            animate: animCtx.enabled,
+                          ),
                         ),
-
                         const SizedBox(height: 16),
-
                         Text(
                           '${_weather!.temperature.round()}°C',
                           style: TextStyle(
@@ -179,7 +189,6 @@ class _WeatherPageState extends State<WeatherPage> {
                           ),
                         ),
                         const SizedBox(height: 8),
-
                         Text(
                           '${_translate(_weather?.condition)} - ${isDayTime ? "Dia" : "Noite"}',
                           style: TextStyle(
@@ -188,7 +197,6 @@ class _WeatherPageState extends State<WeatherPage> {
                             fontWeight: FontWeight.w500,
                           ),
                         ),
-
                         if (_accuracy != null) ...[
                           const SizedBox(height: 4),
                           Text(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   geocoding: ^4.0.0
   lottie: ^3.3.1
   video_player: ^2.5.0
+  shared_preferences: ^2.2.2
   
 dev_dependencies:
   flutter_test:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:weather_app/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('App builds without crashing', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the MaterialApp is present.
+    expect(find.byType(MaterialApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add AnimationContext to toggle app-wide animations and persist user preference
- expose toggle button on weather page to enable/disable animations
- respect animation setting in background and Lottie assets

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fcbf65c0832ea6df493bdc01ec0e